### PR TITLE
Clamp group speed to minimum threshold

### DIFF
--- a/config.py
+++ b/config.py
@@ -59,8 +59,8 @@ class Config:
     TURN_RATE_MAX: float = 0.25
 
     # adaptive speed
-    V_MAX_FAR: float = 4.0
-    V_MIN_NEAR: float = 0.6
+    V_MAX_FAR: float = 4.0     # speed cap in open areas
+    V_MIN_NEAR: float = 0.6    # minimum speed cap near obstacles
     SLOW_RADIUS: float = 8.0
     K_VEL_TRACK: float = 1.9
 

--- a/control.py
+++ b/control.py
@@ -268,7 +268,8 @@ class SwarmController:
                 cl = 1000.0 if self.planner._los(pos[i], pos[i] + leader_dir * 1000.0) else 3.0
             clear_list.append(cl)
         cl_soft = float(np.percentile(np.array(clear_list), perc))
-        v_cap_group = min(cfg.V_MAX_FAR, cl_soft / max(ttc_slow, 1e-6))
+        v_cap_group = max(cfg.V_MIN_NEAR,
+                          min(cfg.V_MAX_FAR, cl_soft / max(ttc_slow, 1e-6)))
 
         anchor = self.leader_anchor(pos, vel)
         max_lag = 0.0


### PR DESCRIPTION
## Summary
- Ensure group velocity cap never drops below config-defined V_MIN_NEAR
- Document minimum speed cap in Config for clarity

## Testing
- `pytest -q`
- ⚠️ `pip install numpy -q` *(failed: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68af4bb673508321a1a6ee7e9eb46541