### PR TITLE
Add configurable group clearance mode

### DIFF
--- a/config.py
+++ b/config.py
@@ -64,6 +64,10 @@ class Config:
     SLOW_RADIUS: float = 8.0
     K_VEL_TRACK: float = 1.9
 
+    # grup hız tavanı için boşluk hesaplama modu
+    GROUP_CLEAR_MODE: str = "blend"      # 'leader' veya 'blend'
+    GROUP_CLEAR_PERCENTILE: float = 70.0  # blend için yüzde (0..100)
+
     # waypoints
     WAYPOINTS: np.ndarray = field(default_factory=lambda: np.array([[6,4],[18,6],[34,20],[8,20],[36,8]], dtype=float))
 


### PR DESCRIPTION
## Summary
- Support leader-only or blended group clearance for speed caps
- Expose `GROUP_CLEAR_MODE` and `GROUP_CLEAR_PERCENTILE` in config with updated comments

## Testing
- `pytest -q`
- `python - <<'PY'
from config import Config
from models import Drone
from environment import Environment
from control import SwarmController
import numpy as np

cfg = Config()
env = Environment(cfg)
drones = [Drone(i, np.array([2 + i*0.5, 20 + i*0.5], dtype=float), np.zeros(2)) for i in range(cfg.N)]
swarm = SwarmController(cfg, env, drones, leader_idx=0)
for _ in range(10):
    swarm.step()
print('sim steps done, leader pos:', swarm.positions()[0])
PY` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68af4bba1d2c8321b4a4f97030ef44ca